### PR TITLE
Fix UI readiness events to restore game rendering

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -153,6 +153,7 @@ export class Game extends Phaser.Scene {
     this.elapsed = 0;
     this.paused = false;
     this.ended = false;
+    this.uiReady = false;
     this.equilibriumStable = 0;
     this.nukeUsed = false;
     this.interventionsUsed = 0;
@@ -171,7 +172,9 @@ export class Game extends Phaser.Scene {
     this.colorblind = getBool(COLORBLIND_KEY, this.colorblind);
     setMutedAudio(this.muted);
     this.palette = getPalette(this.colorblind);
-    this.ui.setMutedAndColorblind(this.muted, this.colorblind);
+    if (this.uiReady) {
+      this.ui.setMutedAndColorblind(this.muted, this.colorblind);
+    }
   }
 
   private buildGroups(): void {

--- a/src/scenes/UI.ts
+++ b/src/scenes/UI.ts
@@ -31,9 +31,23 @@ export class UI extends Phaser.Scene {
   constructor() {
     super("UI");
   }
-  create() {
+
+  init(): void {
+    this.ready = false;
+  }
+
+  create(): void {
     this.createHud();
     this.createEndPanel();
+    this.ready = true;
+    this.events.emit("ui-ready");
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.ready = false;
+    });
+  }
+
+  isReady(): boolean {
+    return this.ready;
   }
   setMode(mode: Mode): void {
     this.modeText.setText(`Mode: ${mode}`);


### PR DESCRIPTION
## Summary
- add explicit readiness lifecycle to the UI scene and emit a `ui-ready` event when built
- guard game initialization so UI bindings only run once the UI scene is ready and reset readiness on restart

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d41b776ae88329bf57ffab2079b327