### PR TITLE
Add elemental protocol SVG icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,32 @@ npm run build
 ```
 
 The production bundle lands in `dist/`. Zip the **contents** of that folder (not the folder itself) for itch.io, then follow the checklist in `DEPLOYING.md`.
+
+## Elemental Icon Assets
+
+Single-color SVGs that match the techno-element vibe live in `src/assets/icons`:
+
+- `fire-thermal-protocol.svg` – flame profile with protocol nodes for fiery abilities.
+- `water-liquid-node.svg` – droplet silhouette with lattice nodes for support/flow skills.
+- `earth-core-process.svg` – strata badge with a central core for defensive effects.
+
+Each icon is built with rounded strokes, scales crisply from 24–128px, and respects `currentColor`. Adjust stroke weight with the `--sw` CSS variable (defaults to `6`).
+
+```css
+.protocol-icon {
+  width: 48px;
+  height: 48px;
+  color: #55e6a5; /* example brand */
+}
+
+.protocol-icon svg {
+  width: 100%;
+  height: 100%;
+  --sw: 5;
+}
+
+/* Optional motion hooks */
+#icon-fire-thermal { filter: drop-shadow(0 0 2px currentColor); animation: flicker 0.28s infinite steps(2, end); }
+#icon-water-liquid circle { animation: pulse 1.6s ease-in-out infinite; }
+.hit #icon-earth-core { animation: wiggle 0.18s linear 1; }
+```

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -438,3 +438,67 @@ input.oracle-input::placeholder {
     transform: scale(1.05) rotate(1.5deg);
   }
 }
+
+/* Elemental protocol icon helpers */
+.protocol-icon {
+  width: 48px;
+  height: 48px;
+  color: #55e6a5;
+}
+
+.protocol-icon svg {
+  width: 100%;
+  height: 100%;
+  --sw: 5;
+}
+
+#icon-fire-thermal {
+  filter: drop-shadow(0 0 2px currentColor);
+  animation: flicker 0.28s infinite steps(2, end);
+}
+
+@keyframes flicker {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.03);
+  }
+  55% {
+    transform: scale(0.99);
+  }
+}
+
+#icon-water-liquid circle {
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.85;
+  }
+}
+
+.hit #icon-earth-core {
+  animation: wiggle 0.18s linear 1;
+}
+
+@keyframes wiggle {
+  0% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(1px);
+  }
+  60% {
+    transform: translateY(-1px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}

--- a/src/assets/icons/earth-core-process.svg
+++ b/src/assets/icons/earth-core-process.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="icon-earth-core" viewBox="0 0 128 128" role="img" aria-labelledby="t" fill="none"
+     stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--sw,6)">
+  <title id="t">Core Process</title>
+  <!-- strata -->
+  <path d="M16 88l18-28 22-10 22 10 18 28H16z"/>
+  <path d="M28 88l20-14 20 14"/>
+  <!-- core -->
+  <circle cx="64" cy="72" r="10"/>
+  <!-- micro traces -->
+  <path d="M64 62v-8M54 72h-8M82 72h8M64 82v8"/>
+</svg>

--- a/src/assets/icons/fire-thermal-protocol.svg
+++ b/src/assets/icons/fire-thermal-protocol.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="icon-fire-thermal" viewBox="0 0 128 128" role="img" aria-labelledby="t" fill="none"
+     stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--sw,6)">
+  <title id="t">Thermal Protocol</title>
+  <!-- outer flame -->
+  <path d="M74 16c4 10-3 18-10 26-6 7-8 14-6 22 3-5 9-9 16-9 12 0 22 9 22 22 0 18-16 31-36 31S24 95 24 76c0-16 12-30 28-42 6-5 10-11 12-18" />
+  <!-- inner spark -->
+  <path d="M58 76c2-4 7-7 12-7 7 0 12 5 12 12 0 9-8 16-18 16-9 0-16-6-16-14" />
+  <!-- protocol nodes -->
+  <circle cx="97" cy="38" r="4"/>
+  <circle cx="108" cy="28" r="4"/>
+  <circle cx="88" cy="26" r="4"/>
+  <path d="M92 28l9 8M97 38l7-10M88 26l9 2"/>
+</svg>

--- a/src/assets/icons/water-liquid-node.svg
+++ b/src/assets/icons/water-liquid-node.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="icon-water-liquid" viewBox="0 0 128 128" role="img" aria-labelledby="t" fill="none"
+     stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--sw,6)">
+  <title id="t">Liquid Node</title>
+  <!-- droplet -->
+  <path d="M64 14c16 26 36 44 36 64 0 22-16 38-36 38S28 100 28 78c0-20 20-38 36-64z"/>
+  <!-- inner lattice -->
+  <circle cx="64" cy="78" r="10"/>
+  <circle cx="44" cy="86" r="7"/>
+  <circle cx="84" cy="92" r="7"/>
+  <path d="M54 82l10-4 10 8M44 86l20-8M84 92l-10-8"/>
+</svg>


### PR DESCRIPTION
## Summary
- add fire, water, and earth protocol SVG icons in src/assets/icons
- document icon usage guidance and hooks in the README
- wire up optional animation helpers for the icons in globals.css

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5647f1a548329919146b502c42a40