### PR TITLE
Add CSS micro-animations for elemental icons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "../ui/icons/animations.css";
+
 :root {
   color-scheme: dark;
   --shadow-oracle: 0 0 45px rgba(34, 211, 238, 0.4);
@@ -450,55 +452,4 @@ input.oracle-input::placeholder {
   width: 100%;
   height: 100%;
   --sw: 5;
-}
-
-#icon-fire-thermal {
-  filter: drop-shadow(0 0 2px currentColor);
-  animation: flicker 0.28s infinite steps(2, end);
-}
-
-@keyframes flicker {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  45% {
-    transform: scale(1.03);
-  }
-  55% {
-    transform: scale(0.99);
-  }
-}
-
-#icon-water-liquid circle {
-  animation: pulse 1.6s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.85;
-  }
-}
-
-.hit #icon-earth-core {
-  animation: wiggle 0.18s linear 1;
-}
-
-@keyframes wiggle {
-  0% {
-    transform: translateY(0);
-  }
-  30% {
-    transform: translateY(1px);
-  }
-  60% {
-    transform: translateY(-1px);
-  }
-  100% {
-    transform: translateY(0);
-  }
 }

--- a/src/ui/icons/animations.css
+++ b/src/ui/icons/animations.css
@@ -1,0 +1,62 @@
+/* Elemental protocol icon animations */
+
+#icon-fire-thermal {
+  filter: drop-shadow(0 0 6px currentColor);
+  animation: flicker 0.28s steps(2, end) infinite;
+  transform-origin: center;
+}
+
+@keyframes flicker {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.03);
+  }
+  65% {
+    transform: scale(0.99);
+  }
+}
+
+#icon-water-liquid circle {
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+#icon-water-liquid circle:nth-of-type(2) {
+  animation-delay: 0.2s;
+}
+
+#icon-water-liquid circle:nth-of-type(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.85;
+  }
+}
+
+.hit #icon-earth-core {
+  animation: wiggle 0.18s linear 1;
+  transform-origin: center;
+}
+
+@keyframes wiggle {
+  0% {
+    transform: translateY(0);
+  }
+  35% {
+    transform: translateY(1px);
+  }
+  65% {
+    transform: translateY(-1px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated UI icon animation stylesheet defining fire flicker, water pulse, and earth hit wiggle
- import the icon animations into the global HUD styles while retaining protocol icon helpers

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d566299868832981fe8c01b2fa319c