### PR TITLE
Add SVG icons for faction shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Single-color SVGs that match the techno-element vibe live in `src/assets/icons`:
 - `fire-thermal-protocol.svg` – flame profile with protocol nodes for fiery abilities.
 - `water-liquid-node.svg` – droplet silhouette with lattice nodes for support/flow skills.
 - `earth-core-process.svg` – strata badge with a central core for defensive effects.
+- `shape-triangle-surge.svg` – angular surge glyph echoing the Fire faction entity profile.
+- `shape-circle-orbit.svg` – orbital ring motif mirroring the Water faction entity silhouette.
+- `shape-hex-lattice.svg` – layered lattice hex emblem representing the Earth faction entity.
 
 Each icon is built with rounded strokes, scales crisply from 24–128px, and respects `currentColor`. Adjust stroke weight with the `--sw` CSS variable (defaults to `6`).
 

--- a/src/assets/icons/shape-circle-orbit.svg
+++ b/src/assets/icons/shape-circle-orbit.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="icon-shape-circle" viewBox="0 0 128 128" role="img" aria-labelledby="t" fill="none"
+     stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--sw,6)">
+  <title id="t">Circle Orbit</title>
+  <!-- outer halo -->
+  <circle cx="64" cy="64" r="46"/>
+  <path d="M26 72a38 38 0 1076-16"/>
+  <!-- inner core -->
+  <circle cx="64" cy="64" r="20"/>
+  <path d="M64 44v12M64 76v12"/>
+  <!-- orbital nodes -->
+  <circle cx="42" cy="54" r="4"/>
+  <circle cx="90" cy="70" r="4"/>
+  <path d="M42 54l12 6M90 70l-12-6"/>
+</svg>

--- a/src/assets/icons/shape-hex-lattice.svg
+++ b/src/assets/icons/shape-hex-lattice.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="icon-shape-hex" viewBox="0 0 128 128" role="img" aria-labelledby="t" fill="none"
+     stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--sw,6)">
+  <title id="t">Hex Lattice</title>
+  <!-- outer shell -->
+  <path d="M64 14l40 24v52l-40 24-40-24V38z"/>
+  <!-- inner frame -->
+  <path d="M64 34l26 16v28L64 94 38 78V50z"/>
+  <!-- lattice -->
+  <path d="M64 42v52"/>
+  <path d="M48 54l32 20M80 54l-32 20"/>
+  <!-- anchor nodes -->
+  <circle cx="64" cy="40" r="4"/>
+  <circle cx="90" cy="56" r="4"/>
+  <circle cx="38" cy="56" r="4"/>
+  <circle cx="64" cy="100" r="4"/>
+</svg>

--- a/src/assets/icons/shape-triangle-surge.svg
+++ b/src/assets/icons/shape-triangle-surge.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="icon-shape-triangle" viewBox="0 0 128 128" role="img" aria-labelledby="t" fill="none"
+     stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--sw,6)">
+  <title id="t">Triangle Surge</title>
+  <!-- outer glyph -->
+  <path d="M64 14l46 84H18z"/>
+  <!-- inner circuit -->
+  <path d="M64 34l30 54H34z"/>
+  <path d="M64 54l14 26H50z"/>
+  <!-- energy nodes -->
+  <circle cx="64" cy="40" r="5"/>
+  <circle cx="86" cy="80" r="4"/>
+  <circle cx="42" cy="80" r="4"/>
+  <!-- trace -->
+  <path d="M64 45v14M64 70v8"/>
+</svg>


### PR DESCRIPTION
## Summary
- add triangle, circle, and hex shape SVG glyphs that match the existing elemental icon styling
- document the new shape icons alongside the elemental assets in the README for easy discovery

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5669ba96c8329951147c7ea35197f