### PR TITLE
Fix alt-mode HUD scaling and rebuild verbose CLI

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -149,6 +149,9 @@ export class Game extends Phaser.Scene {
   private hudLayout: HudLayoutEvent | null = null;
   private nextEntityId = 1;
   private totalEntityCount = 0;
+  private altModeActive = false;
+  private baseCameraZoom = 1;
+  private readonly altModeZoom = 0.92;
   private readonly handleEntityCreated = (sprite: Phaser.Physics.Arcade.Image, faction: FactionId) => {
     this.decorateFactionSprite(sprite, faction, true);
   };
@@ -417,6 +420,9 @@ export class Game extends Phaser.Scene {
     this.globalEntityScale = 1;
     this.lowDetailFx = false;
     this.totalEntityCount = 0;
+    this.altModeActive = false;
+    this.baseCameraZoom = 1;
+    this.cameras.main.setZoom(1);
   }
 
   private initializeSettings(): void {
@@ -428,6 +434,7 @@ export class Game extends Phaser.Scene {
     this.colorblind = getBool(COLORBLIND_KEY, this.colorblind);
     setMutedAudio(this.muted);
     this.palette = getPalette(this.colorblind);
+    this.toggleAltMode(this.colorblind);
     if (this.uiReady) {
       this.ui.setMutedAndColorblind(this.muted, this.colorblind);
     }
@@ -1127,6 +1134,25 @@ export class Game extends Phaser.Scene {
     this.backgroundGrid.setAlpha(fillAlpha);
   }
 
+  private toggleAltMode(on: boolean): void {
+    const camera = this.cameras.main;
+    if (this.altModeActive === on) {
+      if (!on) {
+        camera.setZoom(this.baseCameraZoom);
+      }
+      return;
+    }
+    if (on) {
+      if (!this.altModeActive) {
+        this.baseCameraZoom = camera.zoom;
+      }
+      camera.setZoom(this.altModeZoom);
+    } else {
+      camera.setZoom(this.baseCameraZoom);
+    }
+    this.altModeActive = on;
+  }
+
   private toggleMute(): void {
     this.muted = !this.muted;
     setMutedAudio(this.muted);
@@ -1140,6 +1166,7 @@ export class Game extends Phaser.Scene {
     this.colorblind = !this.colorblind;
     setBool(COLORBLIND_KEY, this.colorblind);
     this.palette = getPalette(this.colorblind);
+    this.toggleAltMode(this.colorblind);
     this.interventions.setPalette(this.palette);
     FACTIONS.forEach((id) => {
       const sprites = this.groups[id].getChildren() as Phaser.Physics.Arcade.Image[];

--- a/src/systems/EventBus.ts
+++ b/src/systems/EventBus.ts
@@ -1,0 +1,3 @@
+import Phaser from "phaser";
+
+export const Bus = new Phaser.Events.EventEmitter();

--- a/src/systems/balanceMeter.ts
+++ b/src/systems/balanceMeter.ts
@@ -1,7 +1,7 @@
-import Phaser from 'phaser';
-import type { FactionId } from '../core/types';
-import { FACTIONS } from '../core/factions';
-import type { Palette } from '../core/palette';
+import Phaser from "phaser";
+import type { FactionId } from "../core/types";
+import { FACTIONS } from "../core/factions";
+import type { Palette } from "../core/palette";
 
 const EQUILIBRIUM_HOT = Phaser.Display.Color.ValueToColor(0xff6347);
 const EQUILIBRIUM_COOL = Phaser.Display.Color.ValueToColor(0x55e6a5);
@@ -76,8 +76,8 @@ export function computeEquilibrium(counts: Counts): number {
 
 export class BalanceBar {
   private readonly graphics: Phaser.GameObjects.Graphics;
-  private readonly width: number;
-  private readonly height: number;
+  private width: number;
+  private height: number;
   private displayedEquilibrium = 1;
 
   constructor(scene: Phaser.Scene, x: number, y: number, width = 320, height = 12) {
@@ -99,12 +99,13 @@ export class BalanceBar {
       Math.floor(this.displayedEquilibrium * 100)
     );
     const borderColor = Phaser.Display.Color.GetColor(stability.r, stability.g, stability.b);
+    const radius = Math.min(Math.max(this.height / 2, 2), 8);
     this.graphics.fillStyle(0x05101d, 0.92);
-    this.graphics.fillRoundedRect(0, 0, width, this.height, 8);
+    this.graphics.fillRoundedRect(0, 0, width, this.height, radius);
 
     if (total <= 0) {
       this.graphics.lineStyle(2, borderColor, 0.95);
-      this.graphics.strokeRoundedRect(0, 0, width, this.height, 8);
+      this.graphics.strokeRoundedRect(0, 0, width, this.height, radius);
       return;
     }
 
@@ -128,20 +129,21 @@ export class BalanceBar {
       );
       const topColor = Phaser.Display.Color.GetColor(lighter.r, lighter.g, lighter.b);
       const bottomColor = Phaser.Display.Color.GetColor(darker.r, darker.g, darker.b);
-      const radius: Phaser.Types.GameObjects.Graphics.RoundedRectRadius =
+      const cornerRadius: Phaser.Types.GameObjects.Graphics.RoundedRectRadius =
         index === 0
-          ? { tl: 8, bl: 8 }
+          ? { tl: radius, bl: radius }
           : index === FACTIONS.length - 1
-            ? { tr: 8, br: 8 }
+            ? { tr: radius, br: radius }
             : { tl: 0, tr: 0, bl: 0, br: 0 };
       this.graphics.fillGradientStyle(topColor, topColor, bottomColor, bottomColor, 0.98, 0.98, 0.92, 0.92);
-      this.graphics.fillRoundedRect(offset, 0, segmentWidth, this.height, radius);
+      this.graphics.fillRoundedRect(offset, 0, segmentWidth, this.height, cornerRadius);
       offset += segmentWidth;
     });
     this.graphics.lineStyle(2, borderColor, 0.95);
-    this.graphics.strokeRoundedRect(0, 0, width, this.height, 8);
+    this.graphics.strokeRoundedRect(0, 0, width, this.height, radius);
     this.graphics.lineStyle(1, borderColor, 0.4);
-    this.graphics.strokeRoundedRect(2, 2, width - 4, this.height - 4, 6);
+    const innerRadius = Math.max(radius - 2, 1);
+    this.graphics.strokeRoundedRect(2, 2, width - 4, this.height - 4, innerRadius);
   }
 
   setVisible(visible: boolean): void {
@@ -152,7 +154,8 @@ export class BalanceBar {
     this.graphics.setPosition(x, y);
   }
 
-  setScale(x: number, y?: number): void {
-    this.graphics.setScale(x, y ?? x);
+  setSize(width: number, height: number): void {
+    this.width = Math.max(0, width);
+    this.height = Math.max(1, height);
   }
 }

--- a/src/systems/log.ts
+++ b/src/systems/log.ts
@@ -1,32 +1,29 @@
-import Phaser from 'phaser';
+import { Bus } from "./EventBus";
 
 export type ElementId = string;
 
 export type GameEvent =
-  | { t: 'hit'; at: number; src: ElementId; dst: ElementId; amount: number; rule: string }
-  | { t: 'kill'; at: number; src: ElementId; dst: ElementId; rule: string }
-  | { t: 'buff'; at: number; who: ElementId; kind: string; dur: number }
-  | { t: 'spawn'; at: number; kind: 'Thermal' | 'Liquid' | 'Core'; n: number }
-  | { t: 'system'; at: number; msg: string };
+  | { t: "hit"; at: number; src: ElementId; dst: ElementId; amount: number; rule: string }
+  | { t: "kill"; at: number; src: ElementId; dst: ElementId; rule: string }
+  | { t: "buff"; at: number; who: ElementId; kind: string; dur: number }
+  | { t: "spawn"; at: number; kind: "Thermal" | "Liquid" | "Core"; n: number }
+  | { t: "system"; at: number; msg: string };
 
 const MAX_BUFFER = 250;
 const buffer: GameEvent[] = [];
-const emitter = new Phaser.Events.EventEmitter();
 
 export const logEvent = (event: GameEvent): void => {
   buffer.push(event);
   if (buffer.length > MAX_BUFFER) {
     buffer.splice(0, buffer.length - MAX_BUFFER);
   }
-  emitter.emit('event', event);
+  Bus.emit("log", event);
 };
 
 export const clearLog = (): void => {
   if (!buffer.length) return;
   buffer.length = 0;
-  emitter.emit('cleared');
+  Bus.emit("log:clear");
 };
 
 export const getLogHistory = (): GameEvent[] => buffer.slice();
-
-export const logEvents = emitter;

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -19,13 +19,16 @@ export const HUD_MONO_FONT_FAMILY =
  * Call setHudScale(1.0–1.5) to globally scale panel padding, typography, and hit areas.
  */
 
-let hudScale = 1;
+export const HUD_SCALE_MIN = 1;
+export const HUD_SCALE_MAX = 1.5;
+
+let hudScale = HUD_SCALE_MIN;
 const listeners = new Set<(scale: number) => void>();
 
 export const getHudScale = (): number => hudScale;
 
 export const setHudScale = (scale: number): void => {
-  const clamped = Math.min(1.5, Math.max(1, scale));
+  const clamped = Math.min(HUD_SCALE_MAX, Math.max(HUD_SCALE_MIN, scale));
   if (Math.abs(clamped - hudScale) < 0.001) {
     return;
   }


### PR DESCRIPTION
## Summary
- add a shared EventBus for streaming combat/system logs
- rebuild the VerboseCLI as a fixed HUD panel with filters, pause, and minimised layout driven by hudScale
- recompute HUD sizing without container scaling, including the balance bar and tooltips, and ensure toggleAltMode only changes the world camera zoom

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddb6a08eb48329948aa2807b69d0d1